### PR TITLE
Removing array to string conversion Notices

### DIFF
--- a/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
+++ b/modules/user_accounts/php/NDB_Form_user_accounts.class.inc
@@ -90,7 +90,9 @@ class NDB_Form_User_Accounts extends NDB_Form
             unset($defaults['Password_hash']);
 
             // get the user's permissions
-            $perms = $user->getPermissionIDs();
+            $perms = array_map(function ($value) {
+                return $value['permID'];
+            }, $user->getPermissionIDs());
 
             // set the user's permission defaults
             foreach ($perms as $value) {
@@ -824,8 +826,12 @@ class NDB_Form_User_Accounts extends NDB_Form
             // add hidden permissions if editor has less permissions than user
             // being edited
             $perms = array_diff(
-                $user->getPermissionIDs(),
-                $editor->getPermissionIDs()
+                array_map(function ($value) {
+                    return $value['permID'];
+                }, $user->getPermissionIDs()),
+                array_map(function ($value) {
+                    return $value['permID'];
+                }, $editor->getPermissionIDs())
             );
             foreach ($perms as $value) {
                 $this->addHidden("permID[$value]", 1);


### PR DESCRIPTION
This pull request remove the PHP Notice:  Array to string conversion` in loris.ca/user_accounts . It extrcat the actual value of the array using the `permID` key.
